### PR TITLE
fix:  delete OptionalMemberExpression

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -14,7 +14,7 @@ export const updateElement = <P extends Attributes>(
     } else if (name === "style" && !isStr(b)) {
       for (const k in { ...a, ...b }) {
         if (!(a && b && a[k] === b[k])) {
-          ; (dom as any)[name][k] = b?.[k] || ""
+          ; (dom as any)[name][k] = b[k] || ""
         }
       }
     } else if (name[0] === "o" && name[1] === "n") {


### PR DESCRIPTION
在if判断中已经使用了b[k]，不需要可选链操作符