### PR TITLE
Fix jsx-runtime type definitions not being included in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dist/*.map",
     "dist/types",
     "jsx-runtime.js",
-    "jsx-runtime.d.js",
+    "jsx-runtime.d.ts",
     "jsx-dev-runtime.js",
     "jsx-dev-runtime.d.ts"
   ],


### PR DESCRIPTION
`jsx-runtime.d.ts` is not being included in the npm bundle, so typescript cannot find the type definitions when using the `react-jsx` jsx compiler mode.