### PR TITLE
diff算法回滚-预处理

### DIFF
--- a/src/reconcile.ts
+++ b/src/reconcile.ts
@@ -179,35 +179,43 @@ const diff = (aCh, bCh) => {
     bTail = bCh.length - 1,
     aMap = null,
     bMap = null,
-    key = (v) => v.key,
+    same = (a, b) => a.key != null && b.key != null && a.key === b.key,
     temp = [],
     actions = []
 
   while (aHead <= aTail && bHead <= bTail) {
-    if (key(aCh[aTail]) !== key(bCh[bTail])) break
-    clone(aCh[aTail], bCh[bTail])
-    temp.push({ op: TAG.UPDATE })
+    if (!same(aCh[aTail], bCh[bTail])) break
+    if (aCh[aTail].type === bCh[bTail].type) {
+      clone(aCh[aTail], bCh[bTail])
+      temp.push({ op: TAG.UPDATE })
+    } else {
+      actions.push({ op: TAG.REPLACE, cur: bCh[bTail], ref: aCh[aTail] })
+    }
     aTail--
     bTail--
   }
 
   while (aHead <= aTail && bHead <= bTail) {
-    if (key(aCh[aHead]) !== key(bCh[bHead])) break
-    clone(aCh[aHead], bCh[bHead])
-    actions.push({ op: TAG.UPDATE })
+    if (!same(aCh[aHead], bCh[bHead])) break
+    if (aCh[aHead].type === bCh[bHead].type) {
+      clone(aCh[aHead], bCh[bHead])
+      actions.push({ op: TAG.UPDATE })
+    } else {
+      actions.push({ op: TAG.REPLACE, cur: bCh[bHead], ref: aCh[aHead] })
+    }
     aHead++
     bHead++
   }
   if (!aMap) {
     aMap = {}
     for (let i = aHead; i <= aTail; i++) {
-      aMap[key(aCh[i])] = i
+      aMap[aCh[i].key] = i
     }
   }
   if (!bMap) {
     bMap = {}
     for (let i = bHead; i <= bTail; i++) {
-      bMap[key(bCh[i])] = i
+      bMap[bCh[i].key] = i
     }
   }
   while (aHead !== aTail + 1 || bHead !== bTail + 1) {
@@ -221,7 +229,7 @@ const diff = (aCh, bCh) => {
     } else if (aTail + 1 <= aHead) {
       actions.push({ op: TAG.INSERT, cur: bElm, ref: aElm })
       bHead++
-    } else if (key(aElm) === key(bElm)) {
+    } else if (aElm.key === bElm.key) {
       if (aElm.type === bElm.type) {
         clone(aElm, bElm)
         actions.push({ op: TAG.UPDATE })
@@ -231,8 +239,8 @@ const diff = (aCh, bCh) => {
       aHead++
       bHead++
     } else {
-      var foundB = bMap[key(aElm)]
-      var foundA = aMap[key(bElm)]
+      var foundB = bMap[aElm.key]
+      var foundA = aMap[bElm.key]
       if (foundB === undefined) {
         removeElement(aElm)
         aHead++


### PR DESCRIPTION
如题，之前尝试了很多diff算法的思路，只有这个算法比较合适
也就是首尾预处理+keymap

vue3/inferno的基于lis算法和其它基于lcs的算法，复杂度基本都是O(nlog2n)，这个复杂度在 fre 中得不偿失
所以还是会滚到之前的算法，也就是vue2/snabbdom的算法，这个算法的复杂度仍旧是O(n)

算法本身复杂度和 vue2 差不多，比 react 更好

但！fre使用两个map，理论上可以计算移动距离，从而决定是向前还是向后移动，这是一种可能的优化

fre 差不多就到此为止了，基本上是最好的算法了，俺只希望它能够稳定下去

