### PR TITLE
fix(commit): 解决Suspense渲染错位问题

### DIFF
--- a/src/commit.ts
+++ b/src/commit.ts
@@ -12,7 +12,11 @@ export const commit = (fiber?: FiberFinish) => {
 
 
   let parent = fiber?.parent?.node
+  let suspenseNodeComment = null
   if (parent?.nodeType === 8) {
+    if (parent?.nodeValue === 'Suspense') {
+      suspenseNodeComment = parent
+    }
     parent = parent.parentNode as any
   }
 
@@ -23,7 +27,7 @@ export const commit = (fiber?: FiberFinish) => {
       comment = fiber?.node?.firstChild
     }
     // console.log(cur?.node, ref?.node)
-    parent.insertBefore(cur?.node, ref?.node)
+    parent.insertBefore(cur?.node, suspenseNodeComment ?? ref?.node)
     if (fiber.isComp) {
       fiber.node = comment
     }


### PR DESCRIPTION
Suspense功能存在缺陷，当Lazy组件加载完成后，渲染Lazy组件时，存在错位问题
```jsx
import { render, lazy, Suspense, h } from '../../src/index'

const Lazy = lazy(() => {
  return new Promise(resolve =>
    setTimeout(
      () =>
        resolve({
          default: () => <div>Hello</div>
        }),
      1000
    )
  )
})

export function App() {
  return (
    <div>
      <Suspense fallback={<div>loading...</div>}>
        <Lazy />
      </Suspense>
      <div>222</div>
    </div>
  )
}

render(<App />, document.getElementById('app'))
```
![VeryCapture_20250812144851](https://github.com/user-attachments/assets/0436862d-6656-4a81-829d-e2cc159bf3a3)

排查到问题是因为在Lazy组件加载完成后，执行diff算法时，首先会删除渲染的fallback的组件，然后针对Lazy组件会生成insert Action，但是 Action对应的ref为空（因为fallback组件被删除），导致插入时实际执行append操作，导致Lazy组件渲染至父元素的最后一个元素
解决方案：通过在commit中针对Suspense组件进行ref覆盖，可以解决错位、以及Suspense深层嵌套错位问题
