### PR TITLE
-fix automate jsx mode children cannot render bug. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
       "import": "./jsx-runtime.js",
       "require": "./jsx-runtime.js",
       "types": "./jsx-runtime.d.ts"
+    },
+    "./jsx-dev-runtime": {
+      "import": "./jsx-dev-runtime.js",
+      "require": "./jsx-dev-runtime.js",
+      "types": "./jsx-dev-runtime.d.ts"
     }
   },
   "typings": "./dist/types/index.d.ts",

--- a/src/h.ts
+++ b/src/h.ts
@@ -4,9 +4,17 @@ import { FC, FreNode, FreText, Fiber } from './type'
 // for jsx2
 export const h = (type: string | FC, props: any, ...kids: FreNode[]) => {
   props = props || {}
-  kids = flat(arrayfy(props.children || kids))
 
-  if (kids.length) props.children = kids.length === 1 ? kids[0] : kids
+  // JSX Transform 会将 children 作为 props 传递
+  if (props.children !== undefined) {
+    kids = flat(arrayfy([props.children]))
+  } else if (kids.length) {
+    kids = flat(arrayfy(kids))
+  }
+
+  if (kids.length) {
+    props.children = kids.length === 1 ? kids[0] : kids
+  }
 
   const key = props.key || null
   const ref = props.ref || null


### PR DESCRIPTION
when use jsx automate mode, jsx render will group children in props which is difference to h render
- package.json lack jsx-dev-runtime declaration because in develop mode use jsx-dev-runtime.js