### PR TITLE
lack of jsx-runtime-dev export

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
       "import": "./jsx-runtime.js",
       "require": "./jsx-runtime.js",
       "types": "./jsx-runtime.d.ts"
+    },
+    "./jsx-dev-runtime": {
+      "import": "./jsx-dev-runtime.js",
+      "require": "./jsx-dev-runtime.js",
+      "types": "./jsx-dev-runtime.d.ts"
     }
   },
   "typings": "./dist/types/index.d.ts",


### PR DESCRIPTION
when use jsx automate mode, need export jsx-dev-runtime config, because in develop mode jsx render use jsxDEV