### PR TITLE
fix jsx runtime when has no kids need delete props.children attr

### DIFF
--- a/src/h.ts
+++ b/src/h.ts
@@ -6,7 +6,9 @@ export const h = (type: string | FC, props: any, ...kids: FreNode[]) => {
   props = props || {}
   kids = flat(arrayfy(props.children || kids))
 
-  if (kids.length) props.children = kids.length === 1 ? kids[0] : kids
+  if (kids.length) {
+    props.children = kids.length === 1 ? kids[0] : kids
+  } else delete props.children
 
   const key = props.key || null
   const ref = props.ref || null


### PR DESCRIPTION
when jsx render mode, all children is in props which means if formatted kids array length equal zero, we need delete props children attribute