### PR TITLE
fix capture bug

### DIFF
--- a/src/reconcile.ts
+++ b/src/reconcile.ts
@@ -73,8 +73,10 @@ const capture = (fiber: Fiber) => {
       fiber.memo = false
       return sibling(fiber)
     }
-    updateHook(fiber)
-
+    const isMatchSuspenseOrErrorBoundary = updateHook(fiber)
+    if(isMatchSuspenseOrErrorBoundary) {
+      return isMatchSuspenseOrErrorBoundary
+    }
   } else {
     updateHost(fiber as FiberHost)
   }


### PR DESCRIPTION
- when match suspense error boundary update hook function will change fiber to its child