### PR TITLE
fix when update comment node occur error

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -36,11 +36,11 @@ export const updateElement = (
     } else if (name in dom && !(dom instanceof SVGElement)) {
       dom[name] = b || ''
     } else if (b == null || b === false) {
-      // @ts-expect-error Property 'removeAttribute' does not exist on type 'Text'.
-      dom.removeAttribute(name)
+      // @ts-expect-error Property 'removeAttribute' does not exist on type 'Text' | type 'Commit'
+      dom.removeAttribute?.(name)
     } else {
-      // @ts-expect-error Property 'setAttribute' does not exist on type 'Text'.
-      dom.setAttribute && dom?.setAttribute(name, b)
+      // @ts-expect-error Property 'setAttribute' does not exist on type 'Text' | type 'Commit'
+      dom.setAttribute?.(name, b)
     }
   })
 }


### PR DESCRIPTION
when click button will flush an update task
update task will update A component which has a comment node
when oldProps {count:true} newProps {count:false}
the jointInter function will throw a error because comment node doesn't have removeAttribute method
by the way: another method is comment node no need to update with prop, just update is text node
```js
function App() {
  const [count, setCount] = useState(false)
  return <A count={count} setCount={setCount} />
}
function A({count, setCount}) {
  return <div>
    <button onClick={()=> setCount(prev => !prev)}>toggle</button>
    <div>{count + ''}</div>
  </div>
}
```