### PR TITLE
optimize: Suspense

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,8 +11,8 @@
 </head>
 
 <body>
-  <div id="app"><h2>Hello Fre + Hono</h2><h1>Hello Fre + Hono</h1></div>
-  <script type="module" src="/src/hydrate.tsx"></script>
+  <div id="app"></div>
+  <script type="module" src="/src/suspense.tsx"></script>
   <script>
   </script>
 </body>

--- a/demo/src/suspense.tsx
+++ b/demo/src/suspense.tsx
@@ -34,6 +34,10 @@ export function App() {
                 <Lazy1 />
                 <div>222</div>
             </Suspense>
+            <Suspense fallback={<div>loading...</div>}>
+                <Lazy1 />
+                <div>222</div>
+            </Suspense>
         </div>
     )
 }

--- a/demo/src/suspense.tsx
+++ b/demo/src/suspense.tsx
@@ -1,26 +1,41 @@
-import { render, lazy, Suspense, h } from '../../src/index'
+import { render, lazy, Suspense, h, useState } from '../../src/index'
 
 const Lazy = lazy(() => {
-  return new Promise(resolve =>
-    setTimeout(
-      () =>
-        resolve({
-          default: () => <div>Hello</div>
-        }),
-      1000
+    return new Promise(resolve =>
+        setTimeout(
+            () =>
+                resolve({
+                    default: () => <div>Hello2</div>
+                }),
+            3000
+        )
     )
-  )
 })
-
+const Lazy1 = lazy(() => {
+    return new Promise(resolve =>
+        setTimeout(
+            () =>
+                resolve({
+                    default: () => <div>Hello1</div>
+                }),
+            2000
+        )
+    )
+})
 export function App() {
-  return (
-    <div>
-      <Suspense fallback={<div>loading...</div>}>
-        <Lazy />
-        <div>222</div>
-      </Suspense>
-    </div>
-  )
+    const [count, setCount] = useState(0)
+    return (
+        <div>
+            <button onClick={() => setCount(prev => prev + 1)}>{count}</button>
+            <Suspense fallback={<div>loading...</div>}>
+                <Lazy />
+            </Suspense>
+            <Suspense fallback={<div>loading...</div>}>
+                <Lazy1 />
+                <div>222</div>
+            </Suspense>
+        </div>
+    )
 }
 
 render(<App />, document.getElementById('app'))

--- a/demo/src/suspense.tsx
+++ b/demo/src/suspense.tsx
@@ -7,7 +7,7 @@ const Lazy = lazy(() => {
                 resolve({
                     default: () => <div>Hello2</div>
                 }),
-            3000
+            1000
         )
     )
 })
@@ -33,6 +33,10 @@ export function App() {
             <Suspense fallback={<div>loading...</div>}>
                 <Lazy1 />
                 <div>222</div>
+                <Suspense fallback={<div>loading...</div>}>
+                    <Lazy />
+                    <div>222</div>
+                </Suspense>
             </Suspense>
             <Suspense fallback={<div>loading...</div>}>
                 <Lazy1 />

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -1,4 +1,4 @@
-import { FiberFinish, FiberHost, HTMLElementEx, Fiber, Ref, TAG } from './type'
+import { FiberFinish, FiberHost, HTMLElementEx, Fiber, Ref, TAG, MODE } from './type'
 import { updateElement } from './dom'
 import { isFn } from './reconcile'
 
@@ -6,6 +6,7 @@ export const commit = (fiber?: FiberFinish) => {
   if (!fiber) {
     return
   }
+  if(fiber.mode & MODE.OFFSCREEN) return commitSibling(fiber.sibling)
   refer(fiber.ref, fiber.node)
   commitSibling(fiber.child)
   let { op, ref, cur } = fiber.action || {}

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -60,6 +60,7 @@ const kidsRefer = (kids: Fiber[]) => {
 }
 
 export const removeElement = (fiber: Fiber, flag: boolean = true) => {
+  fiber.flag = TAG.REMOVE
   if (fiber.isComp) {
     fiber.hooks && fiber.hooks.list.forEach((e) => e[2] && e[2]())
   } else {

--- a/src/reconcile.ts
+++ b/src/reconcile.ts
@@ -67,7 +67,7 @@ const suspenseRender = (fiber, promise) => {
     suspendPromiseMap.set(promise, new Set([boundary]))
     promise.then(() => {
       const s = suspendPromiseMap.get(promise);
-      ([...s]).filter(b => !b.hasOwnProperty('isOutdated')).forEach(b => update(b))
+      ([...s]).filter(b => !(b.flag && (b.flag & TAG.REPLACE || b.flag & TAG.REMOVE))).forEach(b => update(b))
     }).finally(() => suspendPromiseMap.delete(promise))
   } else pSet.add(boundary)
   return boundary
@@ -214,7 +214,7 @@ function clone(a: Fiber, b: Fiber) {
   b.ref = a.ref
   b.node = a.node
   b.kids = a.kids
-  a.isOutdated = true
+  a.flag = TAG.REPLACE
   b.alternate = a
 }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -98,7 +98,7 @@ interface FiberBase {
   lane?: number,
   suspend?: boolean,
   hydrating?: boolean,
-  isOutdated?: boolean
+  flag?: TAG
 }
 
 export interface Action {

--- a/src/type.ts
+++ b/src/type.ts
@@ -98,6 +98,7 @@ interface FiberBase {
   lane?: number,
   suspend?: boolean,
   hydrating?: boolean,
+  isOutdated?: boolean
 }
 
 export interface Action {

--- a/src/type.ts
+++ b/src/type.ts
@@ -99,8 +99,14 @@ interface FiberBase {
   suspend?: boolean,
   hydrating?: boolean,
   flag?: TAG
+  mode?: MODE
 }
 
+export const SUSPENSE_FALLBACK_KEY = 'SUSPENSE_FALLBACK'
+
+export const enum MODE {
+  OFFSCREEN = 1 << 1
+}
 export interface Action {
   op: TAG
   cur?: Fiber


### PR DESCRIPTION
fix suspense render function to fix two situations:
- Fixed the issue where outdated fibers caused the fallback to be incorrectly rendered multiple times during component updates by applying validity checks to the fibers.
- Fixed the issue where clearing the Suspense kids while rendering the fallback prevented reconciliation from occurring.